### PR TITLE
Scaffold document validation Spring Boot service

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,21 @@ Guided prompt builder for users
 Admin UI for report review and approval
 CAPA linking & effectivity dashboard
 
+
+## 🏃‍♂️ Running Locally
+
+Build and start the application:
+
+```bash
+mvn spring-boot:run
+```
+
+The service exposes a POST `/api/validate` endpoint. Example payload:
+
+```json
+{
+  "systemPrompt": "You are a quality assurance expert...",
+  "guideLineText": "Follow these guidelines...",
+  "documentText": "This deviation report describes..."
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.4</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>docucheck</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>docucheck</name>
+    <description>Document validation engine skeleton</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/docucheck/DocucheckApplication.java
+++ b/src/main/java/com/example/docucheck/DocucheckApplication.java
@@ -1,0 +1,11 @@
+package com.example.docucheck;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DocucheckApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DocucheckApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/docucheck/controller/ValidationController.java
+++ b/src/main/java/com/example/docucheck/controller/ValidationController.java
@@ -1,0 +1,24 @@
+package com.example.docucheck.controller;
+
+import com.example.docucheck.model.ValidationRequest;
+import com.example.docucheck.model.ValidationResponse;
+import com.example.docucheck.service.ValidationService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class ValidationController {
+    private final ValidationService service;
+
+    public ValidationController(ValidationService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/validate")
+    public ValidationResponse validate(@RequestBody ValidationRequest request) {
+        return service.validate(request);
+    }
+}

--- a/src/main/java/com/example/docucheck/model/ValidationRequest.java
+++ b/src/main/java/com/example/docucheck/model/ValidationRequest.java
@@ -1,0 +1,31 @@
+package com.example.docucheck.model;
+
+public class ValidationRequest {
+    private String systemPrompt;
+    private String guideLineText;
+    private String documentText;
+
+    public String getSystemPrompt() {
+        return systemPrompt;
+    }
+
+    public void setSystemPrompt(String systemPrompt) {
+        this.systemPrompt = systemPrompt;
+    }
+
+    public String getGuideLineText() {
+        return guideLineText;
+    }
+
+    public void setGuideLineText(String guideLineText) {
+        this.guideLineText = guideLineText;
+    }
+
+    public String getDocumentText() {
+        return documentText;
+    }
+
+    public void setDocumentText(String documentText) {
+        this.documentText = documentText;
+    }
+}

--- a/src/main/java/com/example/docucheck/model/ValidationResponse.java
+++ b/src/main/java/com/example/docucheck/model/ValidationResponse.java
@@ -1,0 +1,43 @@
+package com.example.docucheck.model;
+
+import java.util.List;
+import java.util.Map;
+
+public class ValidationResponse {
+    private String validationStatus;
+    private Map<String, String> complianceBreakdown;
+    private List<String> recommendations;
+
+    public ValidationResponse() {
+    }
+
+    public ValidationResponse(String validationStatus, Map<String, String> complianceBreakdown, List<String> recommendations) {
+        this.validationStatus = validationStatus;
+        this.complianceBreakdown = complianceBreakdown;
+        this.recommendations = recommendations;
+    }
+
+    public String getValidationStatus() {
+        return validationStatus;
+    }
+
+    public void setValidationStatus(String validationStatus) {
+        this.validationStatus = validationStatus;
+    }
+
+    public Map<String, String> getComplianceBreakdown() {
+        return complianceBreakdown;
+    }
+
+    public void setComplianceBreakdown(Map<String, String> complianceBreakdown) {
+        this.complianceBreakdown = complianceBreakdown;
+    }
+
+    public List<String> getRecommendations() {
+        return recommendations;
+    }
+
+    public void setRecommendations(List<String> recommendations) {
+        this.recommendations = recommendations;
+    }
+}

--- a/src/main/java/com/example/docucheck/service/ValidationService.java
+++ b/src/main/java/com/example/docucheck/service/ValidationService.java
@@ -1,0 +1,24 @@
+package com.example.docucheck.service;
+
+import com.example.docucheck.model.ValidationRequest;
+import com.example.docucheck.model.ValidationResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class ValidationService {
+    public ValidationResponse validate(ValidationRequest request) {
+        Map<String, String> breakdown = new HashMap<>();
+        breakdown.put("description", "pending");
+        breakdown.put("impactAssessment", "pending");
+
+        return new ValidationResponse(
+                "Pending",
+                breakdown,
+                List.of("LLM integration not yet implemented")
+        );
+    }
+}

--- a/src/test/java/com/example/docucheck/DocucheckApplicationTests.java
+++ b/src/test/java/com/example/docucheck/DocucheckApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.docucheck;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DocucheckApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- set up Maven/Spring Boot project skeleton for Codex validator
- add `/api/validate` endpoint with placeholder validation logic
- document local run instructions

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.4 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689068c3cd18832f8387a4bd9ec29d4d