### PR TITLE
feat: add qdrant vector store and prompt chain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,21 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-openai</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-qdrant</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/samichinam/docucheck/controller/ValidationController.java
+++ b/src/main/java/com/samichinam/docucheck/controller/ValidationController.java
@@ -1,7 +1,8 @@
 package com.samichinam.docucheck.controller;
 
-import com.samichinam.docucheck.model.ValidationRequest;
-import com.samichinam.docucheck.model.ValidationResponse;
+import com.samichinam.docucheck.model.*;
+import com.samichinam.docucheck.service.GuidelineService;
+import com.samichinam.docucheck.service.PromptChainService;
 import com.samichinam.docucheck.service.ValidationService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,13 +13,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class ValidationController {
     private final ValidationService service;
+    private final GuidelineService guidelineService;
+    private final PromptChainService promptChainService;
 
-    public ValidationController(ValidationService service) {
+    public ValidationController(ValidationService service, GuidelineService guidelineService, PromptChainService promptChainService) {
         this.service = service;
+        this.guidelineService = guidelineService;
+        this.promptChainService = promptChainService;
     }
 
     @PostMapping("/validate")
     public ValidationResponse validate(@RequestBody ValidationRequest request) {
         return service.validate(request);
+    }
+
+    @PostMapping("/guidelines")
+    public void uploadGuidelines(@RequestBody GuidelineRequest request) {
+        guidelineService.replaceGuidelines(request.getGuidelines());
+    }
+
+    @PostMapping("/prompts/chain")
+    public PromptChainResponse runChain(@RequestBody PromptChainRequest request) {
+        return new PromptChainResponse(promptChainService.executeChain(request.getPrompts()));
     }
 }

--- a/src/main/java/com/samichinam/docucheck/model/GuidelineRequest.java
+++ b/src/main/java/com/samichinam/docucheck/model/GuidelineRequest.java
@@ -1,0 +1,24 @@
+package com.samichinam.docucheck.model;
+
+import java.util.List;
+
+/**
+ * Payload for uploading guideline text to the vector store.
+ */
+public class GuidelineRequest {
+    private List<String> guidelines;
+
+    public GuidelineRequest() {}
+
+    public GuidelineRequest(List<String> guidelines) {
+        this.guidelines = guidelines;
+    }
+
+    public List<String> getGuidelines() {
+        return guidelines;
+    }
+
+    public void setGuidelines(List<String> guidelines) {
+        this.guidelines = guidelines;
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/model/PromptChainRequest.java
+++ b/src/main/java/com/samichinam/docucheck/model/PromptChainRequest.java
@@ -1,0 +1,24 @@
+package com.samichinam.docucheck.model;
+
+import java.util.List;
+
+/**
+ * Request payload containing a sequence of prompts to execute sequentially.
+ */
+public class PromptChainRequest {
+    private List<String> prompts;
+
+    public PromptChainRequest() {}
+
+    public PromptChainRequest(List<String> prompts) {
+        this.prompts = prompts;
+    }
+
+    public List<String> getPrompts() {
+        return prompts;
+    }
+
+    public void setPrompts(List<String> prompts) {
+        this.prompts = prompts;
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/model/PromptChainResponse.java
+++ b/src/main/java/com/samichinam/docucheck/model/PromptChainResponse.java
@@ -1,0 +1,24 @@
+package com.samichinam.docucheck.model;
+
+import java.util.List;
+
+/**
+ * Response object for prompt chain execution.
+ */
+public class PromptChainResponse {
+    private List<String> responses;
+
+    public PromptChainResponse() {}
+
+    public PromptChainResponse(List<String> responses) {
+        this.responses = responses;
+    }
+
+    public List<String> getResponses() {
+        return responses;
+    }
+
+    public void setResponses(List<String> responses) {
+        this.responses = responses;
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/service/GuidelineService.java
+++ b/src/main/java/com/samichinam/docucheck/service/GuidelineService.java
@@ -1,0 +1,64 @@
+package com.samichinam.docucheck.service;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.openai.OpenAiEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Manages persistence of guideline text in a Qdrant vector store.
+ * Existing guidelines are replaced when new guidelines are uploaded.
+ */
+@Service
+public class GuidelineService {
+
+    private EmbeddingStore<TextSegment> store;
+    private final EmbeddingModel embeddingModel;
+
+    public GuidelineService() {
+        this.embeddingModel = OpenAiEmbeddingModel.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .build();
+        this.store = QdrantEmbeddingStore.builder()
+                .host("localhost")
+                .port(6333)
+                .collectionName("guidelines")
+                .dimension(1536)
+                .build();
+    }
+
+    /**
+     * Replaces any existing guidelines with the provided list.
+     */
+    public void replaceGuidelines(List<String> guidelines) {
+        this.store = QdrantEmbeddingStore.builder()
+                .host("localhost")
+                .port(6333)
+                .collectionName("guidelines")
+                .dimension(1536)
+                .recreateCollection(true)
+                .build();
+
+        List<Embedding> embeddings = embeddingModel.embedAll(guidelines);
+        List<TextSegment> segments = guidelines.stream()
+                .map(TextSegment::from)
+                .collect(Collectors.toList());
+        store.addAll(embeddings, segments);
+    }
+
+    /**
+     * Searches for guidelines similar to the given query text.
+     */
+    public List<String> search(String query) {
+        Embedding queryEmbedding = embeddingModel.embed(query);
+        return store.findRelevant(queryEmbedding, 5).stream()
+                .map(match -> match.embedded().text())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/service/PromptChainService.java
+++ b/src/main/java/com/samichinam/docucheck/service/PromptChainService.java
@@ -1,0 +1,34 @@
+package com.samichinam.docucheck.service;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Executes a sequence of prompts, feeding the output of each prompt into the next one.
+ */
+@Service
+public class PromptChainService {
+
+    private final ChatLanguageModel model;
+
+    public PromptChainService() {
+        this.model = OpenAiChatModel.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .build();
+    }
+
+    public List<String> executeChain(List<String> prompts) {
+        List<String> responses = new ArrayList<>();
+        String context = null;
+        for (String prompt : prompts) {
+            String input = context == null ? prompt : context + "\n" + prompt;
+            context = model.generate(input);
+            responses.add(context);
+        }
+        return responses;
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/service/ValidationService.java
+++ b/src/main/java/com/samichinam/docucheck/service/ValidationService.java
@@ -10,15 +10,24 @@ import java.util.Map;
 
 @Service
 public class ValidationService {
+
+    private final GuidelineService guidelineService;
+
+    public ValidationService(GuidelineService guidelineService) {
+        this.guidelineService = guidelineService;
+    }
+
     public ValidationResponse validate(ValidationRequest request) {
         Map<String, String> breakdown = new HashMap<>();
         breakdown.put("description", "pending");
         breakdown.put("impactAssessment", "pending");
 
+        List<String> referencedGuidelines = guidelineService.search(request.getDocumentText());
+
         return new ValidationResponse(
                 "Pending",
                 breakdown,
-                List.of("LLM integration not yet implemented")
+                referencedGuidelines
         );
     }
 }


### PR DESCRIPTION
## Summary
- integrate LangChain4j and Qdrant dependencies
- add `GuidelineService` to store and query guidelines in a Qdrant vector store, replacing prior versions
- support prompt chain execution and guideline upload via new API endpoints

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68906bf86cf0832f92c43c018fb85079