### PR TITLE
refactor: migrate to ChatModel

### DIFF
--- a/src/main/java/com/samichinam/docucheck/service/PromptChainService.java
+++ b/src/main/java/com/samichinam/docucheck/service/PromptChainService.java
@@ -1,6 +1,6 @@
 package com.samichinam.docucheck.service;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +13,7 @@ import java.util.List;
 @Service
 public class PromptChainService {
 
-    private final ChatLanguageModel model;
+    private final ChatModel model;
 
     public PromptChainService() {
         this.model = OpenAiChatModel.builder()
@@ -26,7 +26,7 @@ public class PromptChainService {
         String context = null;
         for (String prompt : prompts) {
             String input = context == null ? prompt : context + "\n" + prompt;
-            context = model.generate(input);
+            context = model.chat(input);
             responses.add(context);
         }
         return responses;


### PR DESCRIPTION
## Summary
- refactor PromptChainService to depend on ChatModel instead of ChatLanguageModel
- update chain execution to use `chat(...)` in place of `generate(...)` for LangChain4j 1.x

## Testing
- `OPENAI_API_KEY=dummy mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689070b7e20c832fad42a1a5a250a03e