### PR TITLE
Add parsing, scoring, prompt builder and admin stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ The system prompt should clearly instruct the LLM to return structured JSON in t
 }
 
 
-Featuers:
+## 🆕 Additional Features
 
-Docx/PDF parsing
-Confidence scoring per section
-Guided prompt builder for users
-Admin UI for report review and approval
-CAPA linking & effectivity dashboard
+- Docx/PDF parsing
+- Confidence scoring per section
+- Guided prompt builder for users
+- Admin endpoints for report review and approval
+- CAPA linking & effectivity dashboard
 
 
 ## 🏃‍♂️ Running Locally

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,18 @@
             <artifactId>langchain4j-qdrant</artifactId>
         </dependency>
 
+        <!-- Document parsing -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.30</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/samichinam/docucheck/controller/AdminController.java
+++ b/src/main/java/com/samichinam/docucheck/controller/AdminController.java
@@ -1,0 +1,61 @@
+package com.samichinam.docucheck.controller;
+
+import com.samichinam.docucheck.model.Capa;
+import com.samichinam.docucheck.model.ValidationResponse;
+import com.samichinam.docucheck.service.CapaService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Minimal admin endpoints for report review and approval.
+ */
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final Map<Integer, ValidationResponse> reports = new ConcurrentHashMap<>();
+    private final AtomicInteger idGen = new AtomicInteger();
+    private final CapaService capaService;
+
+    public AdminController(CapaService capaService) {
+        this.capaService = capaService;
+    }
+
+    @PostMapping("/reports")
+    public int submitReport(@RequestBody ValidationResponse response) {
+        int id = idGen.incrementAndGet();
+        reports.put(id, response);
+        return id;
+    }
+
+    @GetMapping("/reports")
+    public Map<Integer, ValidationResponse> listReports() {
+        return reports;
+    }
+
+    @PostMapping("/reports/{id}/approve")
+    public void approve(@PathVariable int id) {
+        ValidationResponse response = reports.get(id);
+        if (response != null) {
+            response.setValidationStatus("Approved");
+        }
+    }
+
+    @PostMapping("/reports/{id}/link-capa/{capaId}")
+    public void linkCapa(@PathVariable int id, @PathVariable String capaId) {
+        capaService.link(String.valueOf(id), capaId);
+    }
+
+    @GetMapping("/capas")
+    public java.util.List<Capa> capas() {
+        return capaService.all();
+    }
+
+    @PostMapping("/capas/{id}/effective")
+    public void setEffective(@PathVariable String id, @RequestParam boolean value) {
+        capaService.setEffective(id, value);
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/controller/DocumentController.java
+++ b/src/main/java/com/samichinam/docucheck/controller/DocumentController.java
@@ -1,0 +1,31 @@
+package com.samichinam.docucheck.controller;
+
+import com.samichinam.docucheck.service.DocumentParserService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Exposes document parsing for DOCX/PDF files.
+ */
+@RestController
+@RequestMapping("/api/documents")
+public class DocumentController {
+
+    private final DocumentParserService parserService;
+
+    public DocumentController(DocumentParserService parserService) {
+        this.parserService = parserService;
+    }
+
+    @PostMapping("/parse")
+    public String parse(@RequestBody Map<String, String> request) throws IOException {
+        Path path = Path.of(request.get("path"));
+        return parserService.parse(path);
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/controller/ValidationController.java
+++ b/src/main/java/com/samichinam/docucheck/controller/ValidationController.java
@@ -3,6 +3,7 @@ package com.samichinam.docucheck.controller;
 import com.samichinam.docucheck.model.*;
 import com.samichinam.docucheck.service.GuidelineService;
 import com.samichinam.docucheck.service.PromptChainService;
+import com.samichinam.docucheck.service.PromptBuilderService;
 import com.samichinam.docucheck.service.ValidationService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,11 +16,16 @@ public class ValidationController {
     private final ValidationService service;
     private final GuidelineService guidelineService;
     private final PromptChainService promptChainService;
+    private final PromptBuilderService promptBuilderService;
 
-    public ValidationController(ValidationService service, GuidelineService guidelineService, PromptChainService promptChainService) {
+    public ValidationController(ValidationService service,
+                               GuidelineService guidelineService,
+                               PromptChainService promptChainService,
+                               PromptBuilderService promptBuilderService) {
         this.service = service;
         this.guidelineService = guidelineService;
         this.promptChainService = promptChainService;
+        this.promptBuilderService = promptBuilderService;
     }
 
     @PostMapping("/validate")
@@ -35,5 +41,11 @@ public class ValidationController {
     @PostMapping("/prompts/chain")
     public PromptChainResponse runChain(@RequestBody PromptChainRequest request) {
         return new PromptChainResponse(promptChainService.executeChain(request.getPrompts()));
+    }
+
+    @PostMapping("/prompts/build")
+    public PromptBuilderResponse buildPrompt(@RequestBody PromptBuilderRequest request) {
+        String prompt = promptBuilderService.buildPrompt(request.getObjective(), request.getSections());
+        return new PromptBuilderResponse(prompt);
     }
 }

--- a/src/main/java/com/samichinam/docucheck/model/Capa.java
+++ b/src/main/java/com/samichinam/docucheck/model/Capa.java
@@ -1,0 +1,40 @@
+package com.samichinam.docucheck.model;
+
+public class Capa {
+    private String id;
+    private String reportId;
+    private boolean effective;
+
+    public Capa() {
+    }
+
+    public Capa(String id, String reportId, boolean effective) {
+        this.id = id;
+        this.reportId = reportId;
+        this.effective = effective;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getReportId() {
+        return reportId;
+    }
+
+    public void setReportId(String reportId) {
+        this.reportId = reportId;
+    }
+
+    public boolean isEffective() {
+        return effective;
+    }
+
+    public void setEffective(boolean effective) {
+        this.effective = effective;
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/model/PromptBuilderRequest.java
+++ b/src/main/java/com/samichinam/docucheck/model/PromptBuilderRequest.java
@@ -1,0 +1,24 @@
+package com.samichinam.docucheck.model;
+
+import java.util.List;
+
+public class PromptBuilderRequest {
+    private String objective;
+    private List<String> sections;
+
+    public String getObjective() {
+        return objective;
+    }
+
+    public void setObjective(String objective) {
+        this.objective = objective;
+    }
+
+    public List<String> getSections() {
+        return sections;
+    }
+
+    public void setSections(List<String> sections) {
+        this.sections = sections;
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/model/PromptBuilderResponse.java
+++ b/src/main/java/com/samichinam/docucheck/model/PromptBuilderResponse.java
@@ -1,0 +1,20 @@
+package com.samichinam.docucheck.model;
+
+public class PromptBuilderResponse {
+    private String prompt;
+
+    public PromptBuilderResponse() {
+    }
+
+    public PromptBuilderResponse(String prompt) {
+        this.prompt = prompt;
+    }
+
+    public String getPrompt() {
+        return prompt;
+    }
+
+    public void setPrompt(String prompt) {
+        this.prompt = prompt;
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/model/ValidationResponse.java
+++ b/src/main/java/com/samichinam/docucheck/model/ValidationResponse.java
@@ -7,14 +7,19 @@ public class ValidationResponse {
     private String validationStatus;
     private Map<String, String> complianceBreakdown;
     private List<String> recommendations;
+    private Map<String, Double> confidenceScores;
 
     public ValidationResponse() {
     }
 
-    public ValidationResponse(String validationStatus, Map<String, String> complianceBreakdown, List<String> recommendations) {
+    public ValidationResponse(String validationStatus,
+                              Map<String, String> complianceBreakdown,
+                              List<String> recommendations,
+                              Map<String, Double> confidenceScores) {
         this.validationStatus = validationStatus;
         this.complianceBreakdown = complianceBreakdown;
         this.recommendations = recommendations;
+        this.confidenceScores = confidenceScores;
     }
 
     public String getValidationStatus() {
@@ -39,5 +44,13 @@ public class ValidationResponse {
 
     public void setRecommendations(List<String> recommendations) {
         this.recommendations = recommendations;
+    }
+
+    public Map<String, Double> getConfidenceScores() {
+        return confidenceScores;
+    }
+
+    public void setConfidenceScores(Map<String, Double> confidenceScores) {
+        this.confidenceScores = confidenceScores;
     }
 }

--- a/src/main/java/com/samichinam/docucheck/service/CapaService.java
+++ b/src/main/java/com/samichinam/docucheck/service/CapaService.java
@@ -1,0 +1,33 @@
+package com.samichinam.docucheck.service;
+
+import com.samichinam.docucheck.model.Capa;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages linking of reports to CAPAs and tracks their effectiveness.
+ */
+@Service
+public class CapaService {
+
+    private final Map<String, Capa> capas = new ConcurrentHashMap<>();
+
+    public void link(String reportId, String capaId) {
+        capas.computeIfAbsent(capaId, id -> new Capa(id, reportId, false));
+    }
+
+    public void setEffective(String capaId, boolean effective) {
+        Capa capa = capas.get(capaId);
+        if (capa != null) {
+            capa.setEffective(effective);
+        }
+    }
+
+    public List<Capa> all() {
+        return new ArrayList<>(capas.values());
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/service/DocumentParserService.java
+++ b/src/main/java/com/samichinam/docucheck/service/DocumentParserService.java
@@ -1,0 +1,47 @@
+package com.samichinam.docucheck.service;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Simple parser that extracts text from DOCX and PDF documents.
+ */
+@Service
+public class DocumentParserService {
+
+    /**
+     * Parse a document to plain text based on its file extension.
+     * Supports .docx and .pdf files; all other files are treated as UTF-8 text.
+     */
+    public String parse(Path path) throws IOException {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.endsWith(".docx")) {
+            return parseDocx(path);
+        }
+        if (fileName.endsWith(".pdf")) {
+            return parsePdf(path);
+        }
+        return Files.readString(path);
+    }
+
+    private String parseDocx(Path path) throws IOException {
+        try (XWPFDocument doc = new XWPFDocument(Files.newInputStream(path));
+             XWPFWordExtractor extractor = new XWPFWordExtractor(doc)) {
+            return extractor.getText();
+        }
+    }
+
+    private String parsePdf(Path path) throws IOException {
+        try (PDDocument pdf = PDDocument.load(path.toFile())) {
+            PDFTextStripper stripper = new PDFTextStripper();
+            return stripper.getText(pdf);
+        }
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/service/PromptBuilderService.java
+++ b/src/main/java/com/samichinam/docucheck/service/PromptBuilderService.java
@@ -1,0 +1,21 @@
+package com.samichinam.docucheck.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Builds guided prompts for users based on desired sections.
+ */
+@Service
+public class PromptBuilderService {
+
+    public String buildPrompt(String objective, List<String> sections) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Objective: ").append(objective).append("\n\n");
+        for (int i = 0; i < sections.size(); i++) {
+            sb.append(i + 1).append(". ").append(sections.get(i)).append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/service/ValidationService.java
+++ b/src/main/java/com/samichinam/docucheck/service/ValidationService.java
@@ -22,12 +22,16 @@ public class ValidationService {
         breakdown.put("description", "pending");
         breakdown.put("impactAssessment", "pending");
 
+        Map<String, Double> scores = new HashMap<>();
+        breakdown.keySet().forEach(k -> scores.put(k, 1.0));
+
         List<String> referencedGuidelines = guidelineService.search(request.getDocumentText());
 
         return new ValidationResponse(
                 "Pending",
                 breakdown,
-                referencedGuidelines
+                referencedGuidelines,
+                scores
         );
     }
 }

--- a/src/test/java/com/samichinam/docucheck/service/DocumentParserServiceTest.java
+++ b/src/test/java/com/samichinam/docucheck/service/DocumentParserServiceTest.java
@@ -1,0 +1,48 @@
+package com.samichinam.docucheck.service;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DocumentParserServiceTest {
+
+    private final DocumentParserService parser = new DocumentParserService();
+
+    @Test
+    void parsesDocx() throws Exception {
+        Path path = Files.createTempFile("doc", ".docx");
+        try (XWPFDocument doc = new XWPFDocument()) {
+            doc.createParagraph().createRun().setText("Hello DOCX");
+            doc.write(Files.newOutputStream(path));
+        }
+        String text = parser.parse(path);
+        assertTrue(text.contains("Hello DOCX"));
+    }
+
+    @Test
+    void parsesPdf() throws Exception {
+        Path path = Files.createTempFile("pdf", ".pdf");
+        try (PDDocument doc = new PDDocument()) {
+            PDPage page = new PDPage();
+            doc.addPage(page);
+            try (PDPageContentStream cs = new PDPageContentStream(doc, page)) {
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA, 12);
+                cs.newLineAtOffset(100, 700);
+                cs.showText("Hello PDF");
+                cs.endText();
+            }
+            doc.save(path.toFile());
+        }
+        String text = parser.parse(path);
+        assertTrue(text.contains("Hello PDF"));
+    }
+}

--- a/src/test/java/com/samichinam/docucheck/service/PromptBuilderServiceTest.java
+++ b/src/test/java/com/samichinam/docucheck/service/PromptBuilderServiceTest.java
@@ -1,0 +1,20 @@
+package com.samichinam.docucheck.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PromptBuilderServiceTest {
+
+    private final PromptBuilderService service = new PromptBuilderService();
+
+    @Test
+    void buildsPrompt() {
+        String prompt = service.buildPrompt("Review report", List.of("Section A", "Section B"));
+        assertTrue(prompt.contains("Review report"));
+        assertTrue(prompt.contains("1. Section A"));
+        assertTrue(prompt.contains("2. Section B"));
+    }
+}


### PR DESCRIPTION
## Summary
- add DOCX/PDF parser service and endpoint
- track confidence scores in validation responses
- provide prompt builder, admin and CAPA management endpoints

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6890722c0a58832fbcf631795bce87fa