### PR TITLE
Add basic data integrity and training checks

### DIFF
--- a/src/main/java/com/samichinam/docucheck/service/DataIntegrityService.java
+++ b/src/main/java/com/samichinam/docucheck/service/DataIntegrityService.java
@@ -1,0 +1,47 @@
+package com.samichinam.docucheck.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Performs very lightweight ALCOA+ data integrity checks. The goal is not to
+ * provide a production ready implementation but to demonstrate how the feature
+ * described in {@code features.md} could be modelled in code.
+ */
+public class DataIntegrityService {
+
+    /**
+     * Validate a textual record against basic ALCOA+ principles and return any
+     * missing elements. Checks are intentionally simplistic: a record is
+     * considered compliant with a principle if a keyword is present.
+     *
+     * @param record text representing the record to check
+     * @return list of missing ALCOA+ principles
+     */
+    public List<String> checkAlcoaPlus(String record) {
+        List<String> missing = new ArrayList<>();
+        if (record == null || record.isBlank()) {
+            missing.add("legible");
+            missing.add("original");
+            missing.add("accurate");
+            missing.add("attributable");
+            missing.add("contemporaneous");
+            return missing;
+        }
+        String lower = record.toLowerCase();
+        if (!lower.contains("author")) {
+            missing.add("attributable");
+        }
+        if (!lower.contains("timestamp")) {
+            missing.add("contemporaneous");
+        }
+        if (!lower.contains("original")) {
+            missing.add("original");
+        }
+        if (!(lower.contains("accurate") || lower.contains("verified"))) {
+            missing.add("accurate");
+        }
+        // "legible" is assumed satisfied if record is not blank
+        return missing;
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/service/TrainingRecordService.java
+++ b/src/main/java/com/samichinam/docucheck/service/TrainingRecordService.java
@@ -1,0 +1,33 @@
+package com.samichinam.docucheck.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Very small service that verifies investigator training records. It demonstrates
+ * the "Training and qualification checks" feature outlined in {@code features.md}.
+ */
+public class TrainingRecordService {
+
+    /**
+     * Determine which required trainings a person is missing.
+     *
+     * @param person name of the individual to check
+     * @param trainingDatabase mapping from person name to list of completed training IDs
+     * @param required list of trainings required for the investigation
+     * @return list of missing training IDs (empty if none)
+     */
+    public List<String> findMissingTrainings(String person,
+                                             Map<String, List<String>> trainingDatabase,
+                                             List<String> required) {
+        List<String> completed = trainingDatabase.getOrDefault(person, List.of());
+        List<String> missing = new ArrayList<>();
+        for (String need : required) {
+            if (!completed.contains(need)) {
+                missing.add(need);
+            }
+        }
+        return missing;
+    }
+}

--- a/src/test/java/com/samichinam/docucheck/service/DataIntegrityServiceTest.java
+++ b/src/test/java/com/samichinam/docucheck/service/DataIntegrityServiceTest.java
@@ -1,0 +1,28 @@
+package com.samichinam.docucheck.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DataIntegrityServiceTest {
+
+    private final DataIntegrityService service = new DataIntegrityService();
+
+    @Test
+    void passesCompleteRecord() {
+        String record = "Author: Jane\nTimestamp: 2024-01-01\nOriginal document\nAccurate";
+        List<String> missing = service.checkAlcoaPlus(record);
+        assertTrue(missing.isEmpty());
+    }
+
+    @Test
+    void flagsMissingPrinciples() {
+        List<String> missing = service.checkAlcoaPlus("partial record");
+        assertTrue(missing.contains("attributable"));
+        assertTrue(missing.contains("contemporaneous"));
+        assertTrue(missing.contains("original"));
+        assertTrue(missing.contains("accurate"));
+    }
+}

--- a/src/test/java/com/samichinam/docucheck/service/TrainingRecordServiceTest.java
+++ b/src/test/java/com/samichinam/docucheck/service/TrainingRecordServiceTest.java
@@ -1,0 +1,30 @@
+package com.samichinam.docucheck.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TrainingRecordServiceTest {
+
+    private final TrainingRecordService service = new TrainingRecordService();
+
+    @Test
+    void findsMissingTraining() {
+        Map<String, List<String>> db = new HashMap<>();
+        db.put("Alice", List.of("GMP"));
+        List<String> missing = service.findMissingTrainings("Alice", db, List.of("GMP", "Safety"));
+        assertTrue(missing.contains("Safety"));
+        assertTrue(!missing.contains("GMP"));
+    }
+
+    @Test
+    void unknownPersonMissingAll() {
+        Map<String, List<String>> db = new HashMap<>();
+        List<String> missing = service.findMissingTrainings("Bob", db, List.of("GMP"));
+        assertTrue(missing.contains("GMP"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement ALCOA+ data integrity checker
- add training record validation service

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68908619bcc8832f8a44281f36278dc4