### PR TITLE
Add cross-reference and pharmacovigilance feature services

### DIFF
--- a/src/main/java/com/samichinam/docucheck/service/CrossReferenceService.java
+++ b/src/main/java/com/samichinam/docucheck/service/CrossReferenceService.java
@@ -1,0 +1,33 @@
+package com.samichinam.docucheck.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Checks that batch records and SOP references in an investigation are
+ * up to date. The implementation is intentionally simple and compares
+ * the referenced revision of a document against a provided map of the
+ * latest revisions. Any mismatches are returned for further handling.
+ */
+public class CrossReferenceService {
+
+    /**
+     * Determine which referenced documents are outdated.
+     *
+     * @param references mapping of document identifier to referenced revision
+     * @param latest mapping of document identifier to latest revision
+     * @return list of document identifiers that are outdated
+     */
+    public List<String> findOutdatedReferences(Map<String, String> references,
+                                               Map<String, String> latest) {
+        List<String> outdated = new ArrayList<>();
+        for (Map.Entry<String, String> ref : references.entrySet()) {
+            String current = latest.get(ref.getKey());
+            if (current != null && !current.equals(ref.getValue())) {
+                outdated.add(ref.getKey());
+            }
+        }
+        return outdated;
+    }
+}

--- a/src/main/java/com/samichinam/docucheck/service/PharmacovigilanceService.java
+++ b/src/main/java/com/samichinam/docucheck/service/PharmacovigilanceService.java
@@ -1,0 +1,34 @@
+package com.samichinam.docucheck.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Performs extremely naive pharmacovigilance checks by scanning text for
+ * potential adverse event or product complaint statements. This is merely a
+ * demonstrative placeholder for the feature outlined in {@code features.md}.
+ */
+public class PharmacovigilanceService {
+
+    /**
+     * Extract sentences that may describe an adverse event.
+     *
+     * @param text free-form report text
+     * @return list of sentences containing keywords associated with adverse events
+     */
+    public List<String> findPotentialAdverseEvents(String text) {
+        List<String> events = new ArrayList<>();
+        if (text == null || text.isBlank()) {
+            return events;
+        }
+        String[] sentences = text.split("(?<=\\.)\\s+");
+        for (String sentence : sentences) {
+            String lower = sentence.toLowerCase();
+            if (lower.contains("adverse") || lower.contains("complaint") ||
+                lower.contains("side effect")) {
+                events.add(sentence.trim());
+            }
+        }
+        return events;
+    }
+}

--- a/src/test/java/com/samichinam/docucheck/service/CrossReferenceServiceTest.java
+++ b/src/test/java/com/samichinam/docucheck/service/CrossReferenceServiceTest.java
@@ -1,0 +1,36 @@
+package com.samichinam.docucheck.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CrossReferenceServiceTest {
+
+    private final CrossReferenceService service = new CrossReferenceService();
+
+    @Test
+    void identifiesOutdatedReferences() {
+        Map<String, String> references = Map.of(
+            "SOP-001", "1",
+            "BR-100", "A"
+        );
+        Map<String, String> latest = Map.of(
+            "SOP-001", "2",
+            "BR-100", "A"
+        );
+        List<String> outdated = service.findOutdatedReferences(references, latest);
+        assertEquals(List.of("SOP-001"), outdated);
+    }
+
+    @Test
+    void returnsEmptyWhenNoOutdated() {
+        Map<String, String> references = Map.of("SOP-001", "2");
+        Map<String, String> latest = Map.of("SOP-001", "2");
+        List<String> outdated = service.findOutdatedReferences(references, latest);
+        assertTrue(outdated.isEmpty());
+    }
+}

--- a/src/test/java/com/samichinam/docucheck/service/PharmacovigilanceServiceTest.java
+++ b/src/test/java/com/samichinam/docucheck/service/PharmacovigilanceServiceTest.java
@@ -1,0 +1,27 @@
+package com.samichinam.docucheck.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PharmacovigilanceServiceTest {
+
+    private final PharmacovigilanceService service = new PharmacovigilanceService();
+
+    @Test
+    void extractsAdverseEventSentences() {
+        String text = "Patient reported nausea. Later an adverse event occurred. No further complaint.";
+        List<String> events = service.findPotentialAdverseEvents(text);
+        assertEquals(List.of("Later an adverse event occurred.", "No further complaint."), events);
+    }
+
+    @Test
+    void returnsEmptyWhenNoKeywords() {
+        String text = "Batch executed successfully without incidents.";
+        List<String> events = service.findPotentialAdverseEvents(text);
+        assertTrue(events.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add batch record/SOP cross reference service to flag outdated docs
- add naive pharmacovigilance service to pull potential adverse events
- test new services

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68908ec73124832fbfb7103c6b88cfd6